### PR TITLE
Add link to www.aibase.com in 实时资讯 section

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
     <main id="main">
         <section id="real-time-info" class="content-section">
             <div class="section-header">
-                <h2><i class="fas fa-newspaper"></i> 实时资讯</h2>
+                <h2><i class="fas fa-newspaper"></i> <a href="https://www.aibase.com" target="_blank">实时资讯</a></h2>
                 <p>最新AI领域动态与突破</p>
             </div>
             <div class="card-container">

--- a/tests/welcome.test.js
+++ b/tests/welcome.test.js
@@ -67,6 +67,18 @@ describe('Welcome Page', () => {
     expect(communitySection).not.toBeNull();
     expect(communitySection.querySelector('h2').textContent).toContain('开发者社区');
   });
+  
+  test('should have a link to aibase.com in the real-time info section', () => {
+    const realTimeInfoSection = document.getElementById('real-time-info');
+    expect(realTimeInfoSection).not.toBeNull();
+    
+    // Check if the section header has a link to aibase.com
+    const sectionHeader = realTimeInfoSection.querySelector('.section-header');
+    const headerLink = sectionHeader.querySelector('a');
+    expect(headerLink).not.toBeNull();
+    expect(headerLink.href).toContain('www.aibase.com');
+    expect(headerLink.textContent).toContain('实时资讯');
+  });
 
   test('should have a footer', () => {
     const footer = document.querySelector('footer');


### PR DESCRIPTION
This PR adds a link to www.aibase.com in the 实时资讯 (Real-time Information) section header as requested in issue #4.

Changes made:
1. Added a link to the 实时资讯 section header in index.html
2. Added a test to verify the link exists and points to the correct URL

All tests are passing.

Fixes #4

@songzhenhua351 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0c1abfc800be4ce1bedf1f25516c3d0b)