### PR TITLE
Fix issue #6: Change 立即探索 button to link to Baidu

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -156,11 +156,14 @@ nav ul li a:hover {
     font-size: 1rem;
     border-radius: 30px;
     box-shadow: 0 4px 15px rgba(37, 99, 235, 0.4);
+    display: inline-block;
+    text-decoration: none;
 }
 
 .cta-button:hover {
     transform: translateY(-3px);
     box-shadow: 0 6px 20px rgba(37, 99, 235, 0.6);
+    color: white;
 }
 
 .hero-animation {

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
         <div class="hero-content">
             <h1>探索AI的无限可能</h1>
             <p>最前沿的人工智能技术资讯、洞察与趋势</p>
-            <button class="cta-button">立即探索</button>
+            <a href="https://www.baidu.com/" class="cta-button">立即探索</a>
         </div>
         <div class="hero-animation">
             <div class="network-animation"></div>

--- a/tests/welcome.test.js
+++ b/tests/welcome.test.js
@@ -40,6 +40,15 @@ describe('Welcome Page', () => {
     const ctaButton = heroContent.querySelector('.cta-button');
     expect(ctaButton).not.toBeNull();
   });
+  
+  test('should have the "立即探索" button link to Baidu', () => {
+    const heroSection = document.querySelector('.hero');
+    const ctaButton = heroSection.querySelector('.cta-button');
+    expect(ctaButton).not.toBeNull();
+    expect(ctaButton.tagName.toLowerCase()).toBe('a');
+    expect(ctaButton.href).toBe('https://www.baidu.com/');
+    expect(ctaButton.textContent).toBe('立即探索');
+  });
 
   test('should have all six required content sections', () => {
     // Check for the six core sections mentioned in the issue


### PR DESCRIPTION
This PR fixes issue #6 by changing the "立即探索" (Explore Now) button in the hero section to redirect to www.baidu.com.

Changes made:
1. Changed the button element to an anchor tag with href="https://www.baidu.com/"
2. Updated the CSS to maintain the button styling for the anchor tag
3. Added a test to verify that the button links to Baidu

All tests are passing.

Closes #6

@songzhenhua351 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9da51eb10e8e4d09aa4c11e7a44898ae)